### PR TITLE
Add check for if isPipSupported

### DIFF
--- a/app/src/main/java/live/mehiz/mpvkt/ui/player/PlayerActivity.kt
+++ b/app/src/main/java/live/mehiz/mpvkt/ui/player/PlayerActivity.kt
@@ -197,7 +197,7 @@ class PlayerActivity : AppCompatActivity() {
 
   override fun onStart() {
     super.onStart()
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && isPipSupported) {
       setPictureInPictureParams(createPipParams())
     }
     WindowCompat.setDecorFitsSystemWindows(window, false)


### PR DESCRIPTION
fix https://github.com/abdallahmehiz/mpvKt/issues/235 
that makes the app unusable on old devices,
with error
"setPictureInPictureParams: Device doesn't support picture-in-picture mode."